### PR TITLE
fix: ensure plugin option association

### DIFF
--- a/src/TransformRunner.ts
+++ b/src/TransformRunner.ts
@@ -19,9 +19,9 @@ export class SourceTransformResult {
   ) {}
 }
 
-export type Plugin =
-  ((babel: typeof Babel) => { visitor: Visitor }) |
-  [(babel: typeof Babel) => { visitor: Visitor }, object];
+export type RawBabelPlugin = (babel: typeof Babel) => { name?: string, visitor: Visitor };
+export type RawBabelPluginWithOptions = [RawBabelPlugin, object];
+export type BabelPlugin = RawBabelPlugin | RawBabelPluginWithOptions;
 
 export type TransformRunnerDelegate = {
   transformStart?: (runner: TransformRunner) => void;
@@ -33,7 +33,7 @@ export type TransformRunnerDelegate = {
 export default class TransformRunner {
   constructor(
     readonly sources: IterableIterator<Source> | Array<Source>,
-    readonly plugins: Array<Plugin>,
+    readonly plugins: Array<BabelPlugin>,
     private readonly delegate: TransformRunnerDelegate = {},
   ) {}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,7 +65,7 @@ export default async function run(args: Array<string>) {
 
   options.loadRequires();
 
-  let plugins = options.getPlugins();
+  let plugins = options.getBabelPlugins();
   let runner: TransformRunner;
 
   if (options.stdio) {

--- a/test/fixtures/plugin/index.js
+++ b/test/fixtures/plugin/index.js
@@ -1,0 +1,6 @@
+module.exports = function() {
+  return {
+    name: 'basic-plugin',
+    visitor: {}
+  }
+};


### PR DESCRIPTION
Previously the basename of the resolved plugin file would be used as the plugin name when applying options. However, that meant that if the file was called "index.js" in the plugin package, i.e. named "my-codemod", it was distributed with, the plugin options would have to be given to a plugin named "index" rather than "my-codemod".