### PR TITLE
fix: ignore ambient babelrc config files

### DIFF
--- a/src/TransformRunner.ts
+++ b/src/TransformRunner.ts
@@ -71,6 +71,7 @@ export default class TransformRunner {
   private transformSource(source: Source): string {
     return transform(source.content, {
       filename: source.path,
+      babelrc: false,
       parserOpts: {
         parser(code: string) {
           return parse(

--- a/test/TransformRunnerTest.ts
+++ b/test/TransformRunnerTest.ts
@@ -36,6 +36,17 @@ describe('TransformRunner', function() {
     );
   });
 
+  it('does not include any plugins not specified explicitly', function() {
+    let source = new Source('a.js', 'export default 0;\n');
+    let runner = new TransformRunner([source], []);
+    let result = Array.from(runner.run());
+
+    deepEqual(
+      result,
+      [new SourceTransformResult(source, 'export default 0;\n', null)]
+    );
+  });
+
   it('allows running plugins with options', function() {
     let source = new Source('a.js', '3 + 4;');
     let plugin = function(babel: typeof Babel) {


### PR DESCRIPTION
There may be a `.babelrc` file in the project where `codemod` is run, but it should not pick up its contents and use the plugins/presets it defines when running. For some reason this wasn't an issue in v1.1.2, but showed up in v1.1.3.