### PR TITLE
test(ci): build with node 6, 8, and 9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ cache:
 notifications:
   email: false
 node_js:
+  - '9'
   - '8'
-  - '7'
   - '6'
 before_install: yarn global add greenkeeper-lockfile@1
 before_script: greenkeeper-lockfile-update


### PR DESCRIPTION
node v7 is no longer supported, so let's replace it with v9.