### PR TITLE
Support decorators when transforming source

### DIFF
--- a/src/TransformRunner.ts
+++ b/src/TransformRunner.ts
@@ -93,7 +93,8 @@ export default class TransformRunner {
                       "functionBind",
                       "functionSent",
                       "objectRestSpread",
-                      "dynamicImport"
+                      "dynamicImport",
+                      "decorators"
                     ]
                   });
                 }


### PR DESCRIPTION
Without the `decorators` plugin specified, running a codemod chokes on any decorator in the source being transformed. Without a way to specify a custom list of plugins, we need to add it to the hardcoded list.