### PR TITLE
Run from AST Explorer

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,7 @@
 > Before contributing, please read our [code of conduct](http://corner.squareup.com/codeofconduct.html).
 
 Much of the [prelude of the Babel contribution guide](https://github.com/babel/babel/blob/7.0/CONTRIBUTING.md#not-sure-where-to-start) also applies for this project, since it operates on and with Babel plugins. In particular:
+
 * [AST Explorer](http://astexplorer.net/#/scUfOmVOG5) is a very useful tool for examining ASTs and prototyping plugins.
 * [The Babel Plugin handbook](https://github.com/thejameskyle/babel-handbook/blob/master/translations/en/plugin-handbook.md#babel-plugin-handbook) is a great resource for understanding Babel plugins.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ babel-codemod rewrites JavaScript using babel plugins.
 
 Install from yarn:
 
-```
+```sh
 $ yarn global add babel-codemod
 ```
 
@@ -18,13 +18,19 @@ This will install the runner as `codemod`. This package requires node v6 or high
 
 The primary interface is as a command line tool, usually run like so:
 
-```
+```sh
 $ codemod --plugin transform-module-name \
   path/to/file.js \
   another/file.js
 ```
 
 This will re-write the files `path/to/file.js` and `another/file.js` by transforming them with the babel plugin `transform-module-name`. Multiple plugins may be specified, and multiple file or directories may be re-written at once.
+
+Plugins may also be loaded from remote URLs, including saved [AST Explorer](https://astexplorer.net/) URLs, using `--remote-plugin`. This feature should only be used as a convenience to load code that you or someone you trust wrote. It will run with your full user privileges, so please exercise caution!
+
+```sh
+$ codemod --remote-plugin URL …
+```
 
 For more detailed options, run `codemod --help`.
 
@@ -34,23 +40,24 @@ There are [many, many existing plugins](https://yarnpkg.com/en/packages?q=babel-
 
 ### Transpiling using babel plugins
 
-`babel-codemod` also supports non-standard/future language features that are not currently supported by the latest version of node.  It does this by leveraging `babel-preset-env` which loads the [latest babel plugins](https://github.com/babel/babel/tree/master/packages/babel-preset-env#support-all-plugins-in-babel-that-are-considered-latest).  This feature is on by default.
+`babel-codemod` also supports non-standard/future language features that are not currently supported by the latest version of node. It does this by leveraging `babel-preset-env` which loads the [latest babel plugins](https://github.com/babel/babel/tree/master/packages/babel-preset-env#support-all-plugins-in-babel-that-are-considered-latest). This feature is on by default.
 
 This feature should support most use cases when writing plugins in advanced JavaScript syntax. However, if you are writing plugins with syntax that is beyond "latest", or you would like to use your own set of plugins and presets, you can pass in the `--find-babel-config` switch in combination with a local `.babelrc` file that lists the presets/plugins you want applied to your plugin code.
 
-```
+```sh
 # Run a local plugin that is passed through locally installed babel plugins
 $ codemod --find-babel-config --plugin ./my-plugin.js src/
 ```
 
-This requires that all babel plugins and presets be installed locally and are listed in your `.babelrc` file.  `babel-codemod` uses `babel-register` under the hood too accomplish this and all `.babelrc` [lookup rules apply](https://babeljs.io/docs/usage/babelrc/#lookup-behavior).
+This requires that all babel plugins and presets be installed locally and are listed in your `.babelrc` file. `babel-codemod` uses `babel-register` under the hood too accomplish this and all `.babelrc` [lookup rules apply](https://babeljs.io/docs/usage/babelrc/#lookup-behavior).
 
 ### Transpiling using TypeScript
-There is currently an [open issue](https://github.com/square/babel-codemod/issues/51) for supporting plugins written in typescript.  In the interim, you can take the same approach using `--require` along with `ts-node/register`. 
+
+There is currently an [open issue](https://github.com/square/babel-codemod/issues/51) for supporting plugins written in typescript. In the interim, you can take the same approach using `--require` along with `ts-node/register`.
 
 For example:
 
-```
+```sh
 # Run a local plugin written with TypeScript.
 $ codemod --require ts-node/register --plugin ./my-plugin.ts src/
 ```
@@ -64,6 +71,7 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md) for information on setting up the proje
 [![Build Status](https://travis-ci.org/square/babel-codemod.svg?branch=master)](https://travis-ci.org/square/babel-codemod) [![dependencies Status](https://david-dm.org/square/babel-codemod/status.svg)](https://david-dm.org/square/babel-codemod) [![Greenkeeper badge](https://badges.greenkeeper.io/square/babel-codemod.svg)](https://greenkeeper.io/)
 
 ## License
+
 Copyright 2017 Square, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lint": "tslint --project .",
     "lint-fix": "tslint --project . --fix",
     "pretest": "yarn lint && tsc --project .",
-    "test": "mocha",
+    "test": "mocha 'test/**/*Test.js'",
     "semantic-release": "semantic-release",
     "commitmsg": "commitlint -e $GIT_PARAMS",
     "precommit": "lint-staged"
@@ -16,6 +16,10 @@
   "lint-staged": {
     "*.ts": [
       "prettier --parser typescript --write",
+      "git add"
+    ],
+    "*.md": [
+      "prettier --write",
       "git add"
     ]
   },
@@ -36,12 +40,16 @@
     "@types/babel-core": "^6.7.14",
     "@types/babel-traverse": "^6.7.16",
     "@types/babylon": "^6.7.15",
+    "@types/get-port": "^3.2.0",
     "@types/glob": "^5.0.30",
+    "@types/got": "^7.1.6",
     "@types/mocha": "^2.2.45",
     "@types/mz": "0.0.32",
     "@types/node": "^9.3.0",
     "@types/rimraf": "2.0.2",
+    "@types/tmp": "^0.0.33",
     "commitlint": "^6.0.1",
+    "get-port": "^3.2.0",
     "globby": "^7.1.1",
     "husky": "^0.14.3",
     "lint-staged": "^6.0.0",
@@ -50,7 +58,9 @@
     "prettier-check": "^2.0.0",
     "rimraf": "2.6.2",
     "semantic-release": "^11.0.2",
+    "source-map-support": "^0.5.0",
     "tslint": "^5.4.2",
+    "tslint-config-prettier": "^1.6.0",
     "typescript": "^2.2.1"
   },
   "dependencies": {
@@ -58,9 +68,12 @@
     "babel-preset-env": "^1.6.1",
     "babel-register": "^6.26.0",
     "glob": "^7.1.2",
+    "got": "^8.0.1",
     "mz": "^2.7.0",
     "recast": "^0.13.0",
-    "resolve": "^1.5.0"
+    "resolve": "^1.5.0",
+    "tmp": "^0.0.33",
+    "whatwg-url": "^6.4.0"
   },
   "engines": {
     "node": ">=6.0.0"

--- a/script/prettier-check
+++ b/script/prettier-check
@@ -4,7 +4,7 @@ const globby = require('globby');
 const { join } = require('path');
 const check = require('prettier-check');
 
-let pathsPromise = globby(['{src,test}/**/*.ts'], {
+let pathsPromise = globby(['{src,test}/**/*.ts', '*.md'], {
   cwd: join(__dirname, '..'),
   gitignore: true
 });

--- a/src/PluginLoader.ts
+++ b/src/PluginLoader.ts
@@ -1,0 +1,16 @@
+import Resolver from './resolvers/Resolver';
+
+export default class PluginLoader {
+  constructor(private readonly resolvers: Array<Resolver>) {}
+
+  async load(source: string): Promise<object> {
+    for (let resolver of this.resolvers) {
+      if (await resolver.canResolve(source)) {
+        let resolvedPath = await resolver.resolve(source);
+        return require(resolvedPath);
+      }
+    }
+
+    throw new Error(`unable to resolve a plugin from source: ${source}`);
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ ${$0} [OPTIONS] [PATH … | --stdio]
 
 OPTIONS
   -p, --plugin PLUGIN               Transform sources with PLUGIN (allows multiple).
+      --remote-plugin URL           Fetch a plugin from URL (allows multiple).
   -o, --plugin-options PLUGIN=OPTS  JSON-encoded OPTS for PLUGIN (allows multiple).
   -r, --require PATH                Require PATH before transform (allows multiple).
       --extensions EXTS             Comma-separated extensions to process (default: "${Array.from(
@@ -25,9 +26,15 @@ OPTIONS
   -h, --help                        Show this help message.
   -d, --dry                         Run plugins without modifying files on disk.
 
+  NOTE: \`--remote-plugin\` should only be used as a convenience to load code that you or someone
+        you trust wrote. It will run with your full user privileges, so please exercise caution!
+
 EXAMPLES
   # Run with a relative plugin on all files in \`src/\`.
   $ ${$0} -p ./typecheck.js src/
+
+  # Run with a remote plugin from astexplorer.net on all files in \`src/\`.
+  $ ${$0} --remote-plugin 'https://astexplorer.net/#/gist/688274…' src/
 
   # Run with multiple plugins.
   $ ${$0} -p ./a.js -p ./b.js some-file.js
@@ -76,7 +83,7 @@ export default async function run(
 
   options.loadRequires();
 
-  let plugins = options.getBabelPlugins();
+  let plugins = await options.getBabelPlugins();
   let runner: TransformRunner;
   let stats = {
     modified: 0,

--- a/src/resolvers/AstExplorerResolver.ts
+++ b/src/resolvers/AstExplorerResolver.ts
@@ -1,0 +1,91 @@
+import { readFile, writeFile } from 'mz/fs';
+import { URL } from 'whatwg-url';
+import NetworkResolver from './NetworkResolver';
+
+const EDITOR_HASH_PATTERN = /^#\/gist\/(\w+)(?:\/(\w+))?$/;
+
+/**
+ * Resolves plugins from AST Explorer transforms.
+ *
+ * astexplorer.net uses GitHub gists to save and facilitate sharing. This
+ * resolver accepts either the editor URL or the gist API URL.
+ */
+export default class AstExplorerResolver extends NetworkResolver {
+  constructor(
+    private readonly baseURL: URL = new URL('https://astexplorer.net/')
+  ) {
+    super();
+  }
+
+  async canResolve(source: string): Promise<boolean> {
+    if (await super.canResolve(source)) {
+      let url = new URL(await this.normalize(source));
+
+      return (
+        this.matchesHost(url) &&
+        /^\/api\/v1\/gist\/[a-f0-9]+(\/[a-f0-9]+)?$/.test(url.pathname)
+      );
+    }
+
+    return false;
+  }
+
+  async resolve(source: string): Promise<string> {
+    let filename = await super.resolve(await this.normalize(source));
+    let text = await readFile(filename, { encoding: 'utf8' });
+    let data;
+
+    try {
+      data = JSON.parse(text);
+    } catch {
+      throw new Error(
+        `data loaded from ${source} is not JSON: ${text.slice(0, 100)}`
+      );
+    }
+
+    if (
+      !data ||
+      !data.files ||
+      !data.files['transform.js'] ||
+      !data.files['transform.js'].content
+    ) {
+      throw new Error(
+        "'transform.js' could not be found, perhaps transform is disabled"
+      );
+    }
+
+    await writeFile(filename, data.files['transform.js'].content, {
+      encoding: 'utf8'
+    });
+
+    return filename;
+  }
+
+  async normalize(source: string): Promise<string> {
+    let url = new URL(source);
+
+    if (!this.matchesHost(url)) {
+      return source;
+    }
+
+    let match = url.hash.match(EDITOR_HASH_PATTERN);
+
+    if (!match) {
+      return source;
+    }
+
+    let path = `/api/v1/gist/${match[1]}`;
+
+    if (match[2]) {
+      path += `/${match[2]}`;
+    }
+
+    return new URL(path, this.baseURL).toString();
+  }
+
+  private matchesHost(url: URL): boolean {
+    return (
+      url.protocol === this.baseURL.protocol && url.host === this.baseURL.host
+    );
+  }
+}

--- a/src/resolvers/FileSystemResolver.ts
+++ b/src/resolvers/FileSystemResolver.ts
@@ -1,0 +1,54 @@
+import { stat } from 'mz/fs';
+import { resolve } from 'path';
+import Resolver from './Resolver';
+
+const DEFAULT_PLUGIN_EXTENSIONS = new Set(['.js']);
+
+async function isFile(path: string): Promise<boolean> {
+  try {
+    return (await stat(path)).isFile();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Resolves file system paths to plugins.
+ */
+export default class FileSystemResolver implements Resolver {
+  constructor(
+    private readonly optionalExtensions: Set<string> = DEFAULT_PLUGIN_EXTENSIONS
+  ) {}
+
+  private *enumerateCandidateSources(source: string): IterableIterator<string> {
+    yield resolve(source);
+
+    for (let ext of this.optionalExtensions) {
+      if (ext[0] !== '.') {
+        yield resolve(`${source}.${ext}`);
+      } else {
+        yield resolve(source + ext);
+      }
+    }
+  }
+
+  async canResolve(source: string): Promise<boolean> {
+    for (let candidate of this.enumerateCandidateSources(source)) {
+      if (await isFile(candidate)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  async resolve(source: string): Promise<string> {
+    for (let candidate of this.enumerateCandidateSources(source)) {
+      if (await isFile(candidate)) {
+        return candidate;
+      }
+    }
+
+    throw new Error(`unable to resolve file from source: ${source}`);
+  }
+}

--- a/src/resolvers/NetworkResolver.ts
+++ b/src/resolvers/NetworkResolver.ts
@@ -1,0 +1,39 @@
+import { get, Response } from 'got';
+import { writeFile } from 'mz/fs';
+import { tmpNameSync as tmp } from 'tmp';
+import { URL } from 'whatwg-url';
+import Resolver from './Resolver';
+
+export class NetworkLoadError extends Error {
+  constructor(readonly response: Response<string>) {
+    super(`failed to load plugin from '${response.url}'`);
+  }
+}
+
+/**
+ * Resolves plugins over the network to a local file.
+ *
+ * This plugin accepts only absolute HTTP URLs.
+ */
+export default class NetworkResolver implements Resolver {
+  async canResolve(source: string): Promise<boolean> {
+    try {
+      let url = new URL(source);
+      return url.protocol === 'http:' || url.protocol === 'https:';
+    } catch {
+      return false;
+    }
+  }
+
+  async resolve(source: string): Promise<string> {
+    let response = await get(source, { followRedirect: true });
+
+    if (response.statusCode !== 200) {
+      throw new NetworkLoadError(response);
+    }
+
+    let filename = tmp();
+    await writeFile(filename, response.body);
+    return filename;
+  }
+}

--- a/src/resolvers/PackageResolver.ts
+++ b/src/resolvers/PackageResolver.ts
@@ -1,0 +1,23 @@
+import { sync as resolveSync } from 'resolve';
+import Resolver from './Resolver';
+
+/**
+ * Resolves node modules by name relative to the working directory.
+ *
+ * For example, if used in a project that includes `myplugin` in its
+ * `node_modules`, this class will resolve to the main file of `myplugin`.
+ */
+export default class PackageResolver implements Resolver {
+  async canResolve(source: string): Promise<boolean> {
+    try {
+      await this.resolve(source);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async resolve(source: string): Promise<string> {
+    return resolveSync(source, { basedir: process.cwd() });
+  }
+}

--- a/src/resolvers/Resolver.ts
+++ b/src/resolvers/Resolver.ts
@@ -1,0 +1,23 @@
+/**
+ * Resolvers locate plugin paths given a source string.
+ */
+export default interface Resolver {
+  /**
+   * Determines whether the source can be resolved by this resolver. This should
+   * not necessarily determine whether the source actually does resolve to
+   * anything, but rather whether it is of the right form to be resolved.
+   *
+   * For example, if a resolver were written to load a plugin from a `data:` URI
+   * then this method might simply check that the URI is a valid `data:` URI
+   * rather than actually decoding and handling the contents of said URI.
+   */
+  canResolve(source: string): Promise<boolean>;
+
+  /**
+   * Determines a file path that, when loaded as JavaScript, exports a babel
+   * plugin suitable for use in the transform pipeline. If `source` does not
+   * actually resolve to a file already on disk, consider writing the contents
+   * to disk in a temporary location.
+   */
+  resolve(source: string): Promise<string>;
+};

--- a/test/fixtures/astexplorer/default.json
+++ b/test/fixtures/astexplorer/default.json
@@ -1,0 +1,115 @@
+{
+  "url":
+    "https://api.github.com/gists/68827467161b95ee48048ff906fab6d8/5ece951309157948661ae732af89209715bfe532",
+  "forks_url":
+    "https://api.github.com/gists/68827467161b95ee48048ff906fab6d8/forks",
+  "commits_url":
+    "https://api.github.com/gists/68827467161b95ee48048ff906fab6d8/commits",
+  "id": "68827467161b95ee48048ff906fab6d8",
+  "git_pull_url":
+    "https://gist.github.com/68827467161b95ee48048ff906fab6d8.git",
+  "git_push_url":
+    "https://gist.github.com/68827467161b95ee48048ff906fab6d8.git",
+  "html_url": "https://gist.github.com/68827467161b95ee48048ff906fab6d8",
+  "files": {
+    "astexplorer.json": {
+      "filename": "astexplorer.json",
+      "type": "application/json",
+      "language": "JSON",
+      "raw_url":
+        "https://gist.githubusercontent.com/astexplorer/68827467161b95ee48048ff906fab6d8/raw/cb6fddcb3f083959bd7a1eb5ad5162a4aae118a7/astexplorer.json",
+      "size": 172,
+      "truncated": false,
+      "content":
+        "{\n  \"v\": 2,\n  \"parserID\": \"babylon6\",\n  \"toolID\": \"babelv6\",\n  \"settings\": {\n    \"babylon6\": {}\n  },\n  \"versions\": {\n    \"babylon6\": \"6.18.0\",\n    \"babelv6\": \"6.26.0\"\n  }\n}"
+    },
+    "source.js": {
+      "filename": "source.js",
+      "type": "application/javascript",
+      "language": "JavaScript",
+      "raw_url":
+        "https://gist.githubusercontent.com/astexplorer/68827467161b95ee48048ff906fab6d8/raw/6fd1298030902993fc1162089b648dd6cd37206d/source.js",
+      "size": 476,
+      "truncated": false,
+      "content":
+        "/**\n * Paste or drop some JavaScript here and explore\n * the syntax tree created by chosen parser.\n * You can use all the cool new features from ES6\n * and even more. Enjoy!\n */\n\nlet tips = [\n  \"Click on any AST node with a '+' to expand it\",\n\n  \"Hovering over a node highlights the \\\n   corresponding part in the source code\",\n\n  \"Shift click on an AST node expands the whole substree\"\n];\n\nfunction printTips() {\n  tips.forEach((tip, i) => console.log(`Tip ${i}:` + tip));\n}\n"
+    },
+    "transform.js": {
+      "filename": "transform.js",
+      "type": "application/javascript",
+      "language": "JavaScript",
+      "raw_url":
+        "https://gist.githubusercontent.com/astexplorer/68827467161b95ee48048ff906fab6d8/raw/610c084b3ef8b9d5d481f01098fb46ff80f7a570/transform.js",
+      "size": 252,
+      "truncated": false,
+      "content":
+        "export default function (babel) {\n  const { types: t } = babel;\n  \n  return {\n    name: \"ast-transform\", // not required\n    visitor: {\n      Identifier(path) {\n        path.node.name = path.node.name.split('').reverse().join('');\n      }\n    }\n  };\n}\n"
+    }
+  },
+  "public": false,
+  "created_at": "2018-01-03T14:16:56Z",
+  "updated_at": "2018-01-03T14:19:43Z",
+  "description": null,
+  "comments": 0,
+  "user": null,
+  "comments_url":
+    "https://api.github.com/gists/68827467161b95ee48048ff906fab6d8/comments",
+  "owner": {
+    "login": "astexplorer",
+    "id": 24887483,
+    "avatar_url": "https://avatars2.githubusercontent.com/u/24887483?v=4",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/astexplorer",
+    "html_url": "https://github.com/astexplorer",
+    "followers_url": "https://api.github.com/users/astexplorer/followers",
+    "following_url":
+      "https://api.github.com/users/astexplorer/following{/other_user}",
+    "gists_url": "https://api.github.com/users/astexplorer/gists{/gist_id}",
+    "starred_url":
+      "https://api.github.com/users/astexplorer/starred{/owner}{/repo}",
+    "subscriptions_url":
+      "https://api.github.com/users/astexplorer/subscriptions",
+    "organizations_url": "https://api.github.com/users/astexplorer/orgs",
+    "repos_url": "https://api.github.com/users/astexplorer/repos",
+    "events_url": "https://api.github.com/users/astexplorer/events{/privacy}",
+    "received_events_url":
+      "https://api.github.com/users/astexplorer/received_events",
+    "type": "User",
+    "site_admin": false
+  },
+  "forks": [],
+  "history": [
+    {
+      "user": {
+        "login": "astexplorer",
+        "id": 24887483,
+        "avatar_url": "https://avatars2.githubusercontent.com/u/24887483?v=4",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/astexplorer",
+        "html_url": "https://github.com/astexplorer",
+        "followers_url": "https://api.github.com/users/astexplorer/followers",
+        "following_url":
+          "https://api.github.com/users/astexplorer/following{/other_user}",
+        "gists_url": "https://api.github.com/users/astexplorer/gists{/gist_id}",
+        "starred_url":
+          "https://api.github.com/users/astexplorer/starred{/owner}{/repo}",
+        "subscriptions_url":
+          "https://api.github.com/users/astexplorer/subscriptions",
+        "organizations_url": "https://api.github.com/users/astexplorer/orgs",
+        "repos_url": "https://api.github.com/users/astexplorer/repos",
+        "events_url":
+          "https://api.github.com/users/astexplorer/events{/privacy}",
+        "received_events_url":
+          "https://api.github.com/users/astexplorer/received_events",
+        "type": "User",
+        "site_admin": false
+      },
+      "version": "5ece951309157948661ae732af89209715bfe532",
+      "committed_at": "2018-01-03T14:16:55Z",
+      "change_status": { "total": 43, "additions": 43, "deletions": 0 },
+      "url":
+        "https://api.github.com/gists/68827467161b95ee48048ff906fab6d8/5ece951309157948661ae732af89209715bfe532"
+    }
+  ],
+  "truncated": false
+}

--- a/test/fixtures/plugin/increment.js
+++ b/test/fixtures/plugin/increment.js
@@ -5,5 +5,5 @@ module.exports = function() {
         path.node.value += 1;
       }
     }
-  }
+  };
 };

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,1 @@
+--require source-map-support/register

--- a/test/unit/OptionsTest.ts
+++ b/test/unit/OptionsTest.ts
@@ -1,12 +1,12 @@
 import { deepEqual, strictEqual } from 'assert';
 import { inspect } from 'util';
-import Options, { ParseOptionsResult } from '../src/Options';
+import Options, { ParseOptionsResult } from '../../src/Options';
 
 describe('Options', function() {
   it('has sensible defaults', function() {
     let options = assertOptionsParsed(Options.parse([]));
     deepEqual(options.extensions, new Set(['.js', '.jsx']));
-    deepEqual(options.plugins, []);
+    deepEqual(options.localPlugins, []);
     deepEqual(options.sourcePaths, []);
     deepEqual(options.requires, []);
     strictEqual(options.pluginOptions.size, 0);
@@ -52,7 +52,7 @@ describe('Options', function() {
     deepEqual(options.pluginOptions.get('my-plugin'), { foo: true });
   });
 
-  it('associates plugin options based on declared name', function() {
+  it('associates plugin options based on declared name', async function() {
     let options = assertOptionsParsed(
       Options.parse([
         '--plugin',
@@ -65,7 +65,7 @@ describe('Options', function() {
     // "basic-plugin" is declared in the plugin file
     deepEqual(options.pluginOptions.get('basic-plugin'), { a: true });
 
-    let babelPlugin = options.getBabelPlugin('basic-plugin');
+    let babelPlugin = await options.getBabelPlugin('basic-plugin');
 
     if (!Array.isArray(babelPlugin)) {
       throw new Error(
@@ -81,7 +81,7 @@ describe('Options', function() {
     deepEqual(options.requires, ['mz'].map(require.resolve));
   });
 
-  it('associates plugin options based on inferred name', function() {
+  it('associates plugin options based on inferred name', async function() {
     let options = assertOptionsParsed(
       Options.parse([
         '--plugin',
@@ -94,7 +94,7 @@ describe('Options', function() {
     // "index" is the name of the file
     deepEqual(options.pluginOptions.get('index'), { a: true });
 
-    let babelPlugin = options.getBabelPlugin('index');
+    let babelPlugin = await options.getBabelPlugin('index');
 
     if (!Array.isArray(babelPlugin)) {
       throw new Error(

--- a/test/unit/TestServer.ts
+++ b/test/unit/TestServer.ts
@@ -1,0 +1,45 @@
+import getPort = require('get-port');
+import { createServer, IncomingMessage, Server, ServerResponse } from 'http';
+import { URL } from 'whatwg-url';
+
+export type RequestHandler = (
+  req: IncomingMessage,
+  res: ServerResponse
+) => void;
+
+export class RealTestServer {
+  private server: Server;
+
+  readonly protocol: string = 'http:';
+  readonly hostname: string = '0.0.0.0';
+
+  constructor(readonly port: number, readonly handler: RequestHandler) {
+    this.server = createServer(handler);
+  }
+
+  async start(): Promise<void> {
+    return new Promise<void>(resolve => {
+      this.server.once('listening', () => resolve());
+      this.server.listen(this.port);
+    });
+  }
+
+  async stop(): Promise<void> {
+    return new Promise<void>(resolve => {
+      this.server.close(() => resolve());
+    });
+  }
+
+  requestURL(path: string): URL {
+    return new URL(`${this.protocol}//${this.hostname}:${this.port}${path}`);
+  }
+}
+
+export async function startServer(
+  handler: RequestHandler
+): Promise<RealTestServer> {
+  let port = await getPort();
+  let server = new RealTestServer(port, handler);
+  await server.start();
+  return server;
+}

--- a/test/unit/TransformRunnerTest.ts
+++ b/test/unit/TransformRunnerTest.ts
@@ -5,7 +5,7 @@ import { NumericLiteral, Program } from 'babel-types';
 import TransformRunner, {
   Source,
   SourceTransformResult
-} from '../src/TransformRunner';
+} from '../../src/TransformRunner';
 
 describe('TransformRunner', function() {
   it('passes source through as-is when there are no plugins', function() {

--- a/test/unit/resolvers/AstExplorerResolverTest.ts
+++ b/test/unit/resolvers/AstExplorerResolverTest.ts
@@ -1,0 +1,120 @@
+import { ok, strictEqual } from 'assert';
+import { readFile } from 'mz/fs';
+import { join } from 'path';
+import AstExplorerResolver from '../../../src/resolvers/AstExplorerResolver';
+import { startServer } from '../TestServer';
+
+describe('AstExplorerResolver', function() {
+  it('normalizes a gist+commit editor URL into an API URL', async function() {
+    let resolver = new AstExplorerResolver();
+    let normalized = await resolver.normalize(
+      'https://astexplorer.net/#/gist/688274/5ece95'
+    );
+
+    strictEqual(
+      normalized,
+      'https://astexplorer.net/api/v1/gist/688274/5ece95'
+    );
+  });
+
+  it('normalizes a gist-only editor URL into an API URL', async function() {
+    let resolver = new AstExplorerResolver();
+    let normalized = await resolver.normalize(
+      'https://astexplorer.net/#/gist/688274'
+    );
+
+    strictEqual(normalized, 'https://astexplorer.net/api/v1/gist/688274');
+  });
+
+  it('extracts the transform from the editor view', async function() {
+    let result = await readFile(
+      join(__dirname, '../../fixtures/astexplorer/default.json'),
+      { encoding: 'utf8' }
+    );
+    let server = await startServer((req, res) => {
+      res.end(result);
+    });
+
+    try {
+      let resolver = new AstExplorerResolver(server.requestURL('/'));
+      strictEqual(
+        await readFile(
+          await resolver.resolve(
+            server.requestURL('/#/gist/abc/def').toString()
+          ),
+          { encoding: 'utf8' }
+        ),
+        JSON.parse(result).files['transform.js'].content
+      );
+    } finally {
+      await server.stop();
+    }
+  });
+
+  it('fails when returned data is not JSON', async function() {
+    let server = await startServer((req, res) => {
+      res.end('this is not JSON');
+    });
+    let url = server.requestURL('/');
+
+    try {
+      let resolver = new AstExplorerResolver(server.requestURL('/'));
+
+      await resolver.resolve(url.toString());
+
+      ok(false, 'resolution to non-JSON data should have failed');
+    } catch (err) {
+      strictEqual(
+        err.message,
+        `data loaded from ${url} is not JSON: this is not JSON`
+      );
+    } finally {
+      await server.stop();
+    }
+  });
+
+  it('fails when files data is not present', async function() {
+    let server = await startServer((req, res) => {
+      res.end(JSON.stringify({}));
+    });
+
+    try {
+      let resolver = new AstExplorerResolver(server.requestURL('/'));
+
+      await resolver.resolve(server.requestURL('/').toString());
+
+      ok(false, 'resolution to data without files should have failed');
+    } catch (err) {
+      strictEqual(
+        err.message,
+        "'transform.js' could not be found, perhaps transform is disabled"
+      );
+    } finally {
+      await server.stop();
+    }
+  });
+
+  it('fails when transform.js is not present', async function() {
+    let server = await startServer((req, res) => {
+      res.end(JSON.stringify({ files: {} }));
+    });
+
+    try {
+      let resolver = new AstExplorerResolver(server.requestURL('/'));
+
+      await resolver.resolve(server.requestURL('/').toString());
+
+      ok(
+        false,
+        'resolution to data without transform.js file should have failed'
+      );
+    } catch (err) {
+      strictEqual(
+        err.message,
+        "'transform.js' could not be found, perhaps transform is disabled"
+      );
+    } finally {
+      await server.stop();
+    }
+  });
+});

--- a/test/unit/resolvers/FileSystemResolverTest.ts
+++ b/test/unit/resolvers/FileSystemResolverTest.ts
@@ -1,0 +1,46 @@
+import { ok, strictEqual } from 'assert';
+import { join } from 'path';
+import FileSystemResolver from '../../../src/resolvers/FileSystemResolver';
+
+describe('FileSystemResolver', function() {
+  it('can resolve any files that exist as-is', async function() {
+    let resolver = new FileSystemResolver();
+    ok(await resolver.canResolve(__filename));
+    strictEqual(await resolver.resolve(__filename), __filename);
+  });
+
+  it('can resolve files by inferring an extension from a configurable set of extensions', async function() {
+    let resolver = new FileSystemResolver(new Set(['.lock']));
+    let yarnLockWithoutExtension = join(__dirname, '../../../yarn');
+    ok(await resolver.canResolve(yarnLockWithoutExtension));
+    strictEqual(
+      await resolver.resolve(yarnLockWithoutExtension),
+      `${yarnLockWithoutExtension}.lock`
+    );
+  });
+
+  it('can resolve files by inferring an dot-less extension from a configurable set of extensions', async function() {
+    let resolver = new FileSystemResolver(new Set(['lock']));
+    let yarnLockWithoutExtension = join(__dirname, '../../../yarn');
+    ok(await resolver.canResolve(yarnLockWithoutExtension));
+    strictEqual(
+      await resolver.resolve(yarnLockWithoutExtension),
+      `${yarnLockWithoutExtension}.lock`
+    );
+  });
+
+  it('fails to resolve a non-existent file', async function() {
+    let resolver = new FileSystemResolver();
+    ok(!await resolver.canResolve('/this/file/is/not/there'));
+
+    try {
+      await resolver.resolve('/this/file/is/not/there');
+      ok(false, 'resolution to a non-existent file should have failed');
+    } catch (err) {
+      strictEqual(
+        err.message,
+        'unable to resolve file from source: /this/file/is/not/there'
+      );
+    }
+  });
+});

--- a/test/unit/resolvers/NetworkResolverTest.ts
+++ b/test/unit/resolvers/NetworkResolverTest.ts
@@ -1,0 +1,87 @@
+import { ok, strictEqual } from 'assert';
+import { readFile } from 'mz/fs';
+import NetworkResolver from '../../../src/resolvers/NetworkResolver';
+import { startServer } from '../TestServer';
+
+describe('NetworkResolver', function() {
+  it('can load data from a URL', async function() {
+    let server = await startServer((req, res) => {
+      res.end('here you go!');
+    });
+
+    try {
+      let resolver = new NetworkResolver();
+      let url = server.requestURL('/gimme');
+
+      ok(
+        await resolver.canResolve(url.toString()),
+        `can load from URL: ${url}`
+      );
+
+      let filename = await resolver.resolve(url.toString());
+
+      strictEqual(
+        await readFile(filename, { encoding: 'utf8' }),
+        'here you go!'
+      );
+    } finally {
+      await server.stop();
+    }
+  });
+
+  it('only resolves absolute HTTP URLs', async function() {
+    let resolver = new NetworkResolver();
+
+    ok(await resolver.canResolve('http://example.com/'));
+    ok(await resolver.canResolve('https://example.com/'));
+    ok(!await resolver.canResolve('/'));
+    ok(!await resolver.canResolve('afp://192.168.0.1/volume/folder/file.js'));
+    ok(!await resolver.canResolve('data:,Hello%2C%20World!'));
+  });
+
+  it('follows redirects', async function() {
+    let server = await startServer((req, res) => {
+      if (req.url === '/') {
+        res.writeHead(302, { Location: '/plugin' });
+        res.end();
+      } else if (req.url === '/plugin') {
+        res.end('redirected successfully!');
+      } else {
+        res.writeHead(404);
+        res.end();
+      }
+    });
+
+    try {
+      let resolver = new NetworkResolver();
+      let filename = await resolver.resolve(server.requestURL('/').toString());
+
+      strictEqual(
+        await readFile(filename, { encoding: 'utf8' }),
+        'redirected successfully!'
+      );
+    } finally {
+      await server.stop();
+    }
+  });
+
+  it('throws if it gets a non-200 response', async function() {
+    let server = await startServer((req, res) => {
+      res.statusCode = 400;
+      res.end();
+    });
+
+    try {
+      let resolver = new NetworkResolver();
+      let url = server.requestURL('/');
+
+      await resolver.resolve(url.toString());
+
+      ok(false, 'expected resolution to fail');
+    } catch (err) {
+      strictEqual(err.message, 'Response code 400 (Bad Request)');
+    } finally {
+      await server.stop();
+    }
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,10 @@
 {
-    "compilerOptions": {
-        "module": "commonjs",
-        "target": "es6",
-        "noImplicitAny": false,
-        "sourceMap": true,
-        "strictNullChecks": true,
-        "declaration": true
-    }
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es6",
+    "noImplicitAny": false,
+    "sourceMap": true,
+    "strictNullChecks": true,
+    "declaration": true
+  }
 }

--- a/tslint.json
+++ b/tslint.json
@@ -1,13 +1,14 @@
 {
-	"rules": {
+  "extends": [
+    "tslint-config-prettier"
+  ],
+  "rules": {
     "array-type": [true, "generic"],
-		"no-unused-expression": true,
-		"no-unused-variable": true,
-		"curly": true,
-		"class-name": true,
-		"semicolon": [true, "always"],
-		"triple-equals": true,
-    "new-parens": true,
+    "no-unused-expression": true,
+    "no-unused-variable": true,
+    "curly": true,
+    "class-name": true,
+    "triple-equals": true,
     "ordered-imports": [true, {"import-sources-order": "case-insensitive", "named-imports-order": "lowercase-first"}],
     "no-any": true,
     "no-namespace": true,
@@ -15,23 +16,6 @@
     "no-var-requires": true,
     "no-var-keyword": true,
     "prefer-for-of": true,
-    "typedef": [true, "parameter", "property-declaration"],
-    "typedef-whitespace": [
-      true,
-      {
-        "call-signature": "nospace",
-        "index-signature": "nospace",
-        "parameter": "nospace",
-        "property-declaration": "nospace",
-        "variable-declaration": "nospace"
-      },
-      {
-        "call-signature": "space",
-        "index-signature": "space",
-        "parameter": "space",
-        "property-declaration": "space",
-        "variable-declaration": "space"
-      }
-    ]
-	}
+    "typedef": [true, "parameter", "property-declaration"]
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -224,12 +224,22 @@
   version "1.1.0"
   resolved "https://registry.npmjs.org/@types/events/-/events-1.1.0.tgz#93b1be91f63c184450385272c47b6496fd028e02"
 
+"@types/get-port@^3.2.0":
+  version "3.2.0"
+  resolved "https://registry.npmjs.org/@types/get-port/-/get-port-3.2.0.tgz#f9e0a11443cc21336470185eae3dfba4495d29bc"
+
 "@types/glob@*", "@types/glob@^5.0.30":
   version "5.0.34"
   resolved "https://registry.npmjs.org/@types/glob/-/glob-5.0.34.tgz#ee626c9be3da877d717911c6101eee0a9871bbf4"
   dependencies:
     "@types/events" "*"
     "@types/minimatch" "*"
+    "@types/node" "*"
+
+"@types/got@^7.1.6":
+  version "7.1.6"
+  resolved "https://registry.npmjs.org/@types/got/-/got-7.1.6.tgz#6d7b32baa10ed3da9f6d894727b2e13a65d536e7"
+  dependencies:
     "@types/node" "*"
 
 "@types/minimatch@*":
@@ -262,6 +272,10 @@
   dependencies:
     "@types/glob" "*"
     "@types/node" "*"
+
+"@types/tmp@^0.0.33":
+  version "0.0.33"
+  resolved "https://registry.npmjs.org/@types/tmp/-/tmp-0.0.33.tgz#1073c4bc824754ae3d10cfab88ab0237ba964e4d"
 
 JSONStream@^1.0.4:
   version "1.3.2"
@@ -1472,6 +1486,10 @@ get-own-enumerable-property-symbols@^2.0.1:
   version "2.0.1"
   resolved "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-2.0.1.tgz#5c4ad87f2834c4b9b4e84549dc1e0650fb38c24b"
 
+get-port@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.npmjs.org/get-port/-/get-port-3.2.0.tgz#dd7ce7de187c06c8bf353796ac71e099f0980ebc"
+
 get-stdin@5.0.1:
   version "5.0.1"
   resolved "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.1.tgz#122e161591e21ff4c52530305693f20e6393a398"
@@ -2102,6 +2120,10 @@ lodash.snakecase@4.1.1:
   version "4.1.1"
   resolved "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz#39d714a35357147837aefd64b5dcbb16becd8f8d"
 
+lodash.sortby@^4.7.0:
+  version "4.7.0"
+  resolved "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
+
 lodash.startcase@4.4.0:
   version "4.4.0"
   resolved "https://registry.npmjs.org/lodash.startcase/-/lodash.startcase-4.4.0.tgz#9436e34ed26093ed7ffae1936144350915d9add8"
@@ -2423,7 +2445,7 @@ os-homedir@^1.0.0:
   version "1.0.2"
   resolved "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
 
-os-tmpdir@^1.0.0, os-tmpdir@^1.0.1:
+os-tmpdir@^1.0.0, os-tmpdir@^1.0.1, os-tmpdir@~1.0.2:
   version "1.0.2"
   resolved "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
 
@@ -2616,6 +2638,10 @@ pseudomap@^1.0.2:
 punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
+
+punycode@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz#5f863edc89b96db09074bad7947bf09056ca4e7d"
 
 q@^1.4.1:
   version "1.5.1"
@@ -2949,6 +2975,12 @@ source-map-support@^0.4.15:
   dependencies:
     source-map "^0.5.6"
 
+source-map-support@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.0.tgz#2018a7ad2bdf8faf2691e5fddab26bed5a2bacab"
+  dependencies:
+    source-map "^0.6.0"
+
 source-map@^0.4.4:
   version "0.4.4"
   resolved "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz#eba4f5da9c0dc999de68032d8b4f76173652036b"
@@ -2959,7 +2991,7 @@ source-map@^0.5.6, source-map@~0.5.1:
   version "0.5.7"
   resolved "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
 
-source-map@~0.6.1:
+source-map@^0.6.0, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
 
@@ -3159,6 +3191,12 @@ timed-out@^4.0.1:
   version "4.0.1"
   resolved "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz#f32eacac5a175bea25d7fab565ab3ed8741ef56f"
 
+tmp@^0.0.33:
+  version "0.0.33"
+  resolved "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
+  dependencies:
+    os-tmpdir "~1.0.2"
+
 to-fast-properties@^1.0.3:
   version "1.0.3"
   resolved "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
@@ -3168,6 +3206,12 @@ tough-cookie@~2.3.3:
   resolved "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz#0b618a5565b6dea90bf3425d04d55edc475a7561"
   dependencies:
     punycode "^1.4.1"
+
+tr46@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz#a8b13fd6bfd2489519674ccde55ba3693b706d09"
+  dependencies:
+    punycode "^2.1.0"
 
 traverse@~0.6.6:
   version "0.6.6"
@@ -3198,6 +3242,10 @@ trim-right@^1.0.1:
 tslib@^1.7.1, tslib@^1.8.0:
   version "1.8.1"
   resolved "https://registry.npmjs.org/tslib/-/tslib-1.8.1.tgz#6946af2d1d651a7b1863b531d6e5afa41aa44eac"
+
+tslint-config-prettier@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.npmjs.org/tslint-config-prettier/-/tslint-config-prettier-1.6.0.tgz#fec1ee8fb07e8f033c63fed6b135af997f31962a"
 
 tslint@^5.4.2:
   version "5.8.0"
@@ -3302,6 +3350,18 @@ verror@1.10.0:
     assert-plus "^1.0.0"
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
+
+webidl-conversions@^4.0.1:
+  version "4.0.2"
+  resolved "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
+
+whatwg-url@^6.4.0:
+  version "6.4.0"
+  resolved "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.4.0.tgz#08fdf2b9e872783a7a1f6216260a1d66cc722e08"
+  dependencies:
+    lodash.sortby "^4.7.0"
+    tr46 "^1.0.0"
+    webidl-conversions "^4.0.1"
 
 which@^1.2.10, which@^1.2.9:
   version "1.3.0"


### PR DESCRIPTION
Begins work on #33.

@hzoo, what do you think of the proposed `--remote-plugin` option in this PR's README? I made it different from `--plugin` out of concern for security. I also think the implementation should probably make you confirm somehow before actually loading it.

---

**TODO:**
- [x] add `--remote-plugin` to help output
- [x] add a CLI test exercising `--remote-plugin`
- [x] document non-astexplorer.net URL loading
- [x] add failing tests for `AstExplorerResolver` and `FileSystemResolver`
- [x] make `TestServer#protocol` be `http:`
- [x] get review from @mcMickJuice 
- [x] get sanity check from @fkling