### PR TITLE
Fix/test errors in windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@types/node": "^8.0.0",
     "@types/rimraf": "2.0.2",
     "commitlint": "^5.2.8",
+    "cross-spawn": "^5.1.0",
     "husky": "^0.14.3",
     "mocha": "^4.1.0",
     "rimraf": "2.6.2",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "commitlint": "^5.2.8",
     "cross-spawn": "^5.1.0",
     "husky": "^0.14.3",
+    "mkdirp": "^0.5.1",
     "mocha": "^4.1.0",
     "rimraf": "2.6.2",
     "semantic-release": "^11.0.2",

--- a/test/CLITest.ts
+++ b/test/CLITest.ts
@@ -45,14 +45,14 @@ async function createTemporaryFile(path: string, content: string): Promise<strin
   await mkdirp(dirname(fullPath));
   await new Promise(resolve => {
     setTimeout(resolve);
-}); //for some reason, if we dont wait another tick we get an ENOENT on windows
+  }); //for some reason, if we dont wait another tick we get an ENOENT on windows
   await writeFile(fullPath, content, 'utf8');
 
   return fullPath;
 }
 
 describe('CLI', function() {
-  beforeEach(function() {
+  afterEach(function() {
     rimraf(getTemporaryFilePath('.'));
   });
 

--- a/test/CLITest.ts
+++ b/test/CLITest.ts
@@ -1,5 +1,5 @@
 import { deepEqual, ok, strictEqual } from 'assert';
-import {spawn} from 'cross-spawn';
+import { spawn } from 'cross-spawn';
 import { mkdirp } from 'mkdirp';
 import { readFile, writeFile } from 'mz/fs';
 import { dirname, join } from 'path';

--- a/test/CLITest.ts
+++ b/test/CLITest.ts
@@ -222,6 +222,9 @@ describe('CLI', function() {
       `error should reference invalid syntax: ${stderr}`
     );
     strictEqual(stdout, '');
-    strictEqual(status, 255);
+
+    let windowsSyntaxErrorCode = 4294967295;
+    let nonWindowsSyntaxErrorCode = 255;
+    ok(status === windowsSyntaxErrorCode || status === nonWindowsSyntaxErrorCode,'status code should indicate SyntaxError');
   });
 });

--- a/test/CLITest.ts
+++ b/test/CLITest.ts
@@ -1,5 +1,5 @@
 import { deepEqual, ok, strictEqual } from 'assert';
-import { execFile } from 'child_process';
+import {spawn} from 'cross-spawn';
 import { mkdir, readFile, writeFile } from 'mz/fs';
 import { basename, dirname, join } from 'path';
 import { sync as rimraf } from 'rimraf';
@@ -12,7 +12,7 @@ type CLIResult = { status: number, stdout: string, stderr: string };
 
 async function runCodemodCLI(args: Array<string>, stdin?: string): Promise<CLIResult> {
   return new Promise((resolve: (result: CLIResult) => void, reject: (error: Error) => void) => {
-    let child = execFile(join(__dirname, '../bin/codemod'), args);
+    let child = spawn(join(__dirname, '../bin/codemod'), args);
     let stdout = '';
     let stderr = '';
 

--- a/test/CLITest.ts
+++ b/test/CLITest.ts
@@ -1,7 +1,8 @@
 import { deepEqual, ok, strictEqual } from 'assert';
 import {spawn} from 'cross-spawn';
-import { mkdir, readFile, writeFile } from 'mz/fs';
-import { basename, dirname, join } from 'path';
+import { mkdirp } from 'mkdirp';
+import { readFile, writeFile } from 'mz/fs';
+import { dirname, join } from 'path';
 import { sync as rimraf } from 'rimraf';
 
 function plugin(name: string): string {
@@ -34,22 +35,6 @@ async function runCodemodCLI(args: Array<string>, stdin?: string): Promise<CLIRe
   });
 }
 
-async function mkdirp(path: string): Promise<void> {
-  let parent = dirname(path);
-  let name = basename(path);
-
-  if (parent === '.' || parent === '/') {
-    try {
-      await mkdir(name);
-    } catch (err) {}
-  } else {
-    await mkdirp(parent);
-    try {
-      await mkdir(path);
-    } catch (err) {}
-  }
-}
-
 function getTemporaryFilePath(path: string): string {
   return join(__dirname, '../tmp', path);
 }
@@ -58,6 +43,9 @@ async function createTemporaryFile(path: string, content: string): Promise<strin
   let fullPath = getTemporaryFilePath(path);
 
   await mkdirp(dirname(fullPath));
+  await new Promise(resolve => {
+    setTimeout(resolve);
+}); //for some reason, if we dont wait another tick we get an ENOENT on windows
   await writeFile(fullPath, content, 'utf8');
 
   return fullPath;

--- a/test/TransformRunnerTest.ts
+++ b/test/TransformRunnerTest.ts
@@ -2,6 +2,7 @@ import { deepEqual, strictEqual } from 'assert';
 import * as Babel from 'babel-core';
 import { NodePath } from 'babel-traverse';
 import { NumericLiteral, Program } from 'babel-types';
+import { EOL } from 'os';
 import TransformRunner, { Source, SourceTransformResult } from '../src/TransformRunner';
 
 describe('TransformRunner', function() {
@@ -37,13 +38,13 @@ describe('TransformRunner', function() {
   });
 
   it('does not include any plugins not specified explicitly', function() {
-    let source = new Source('a.js', 'export default 0;\n');
+    let source = new Source('a.js', `export default 0;${EOL}`);
     let runner = new TransformRunner([source], []);
     let result = Array.from(runner.run());
 
     deepEqual(
       result,
-      [new SourceTransformResult(source, 'export default 0;\n', null)]
+      [new SourceTransformResult(source, `export default 0;${EOL}`, null)]
     );
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1137,7 +1137,7 @@ cosmiconfig@^3.0.1, cosmiconfig@^3.1.0:
     parse-json "^3.0.0"
     require-from-string "^2.0.1"
 
-cross-spawn@^5.0.1:
+cross-spawn@^5.0.1, cross-spawn@^5.1.0:
   version "5.1.0"
   resolved "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
   dependencies:


### PR DESCRIPTION
https://github.com/square/babel-codemod/issues/32

* replaced `\n` with os.EOL
* added `cross-spawn` as child_process stuff in windows is somewhat broken
* included windows syntaxerror code to test
* added `mkdirp` package as the existing implementation was causing Stack Overflows (due to how native mkdirp works in windows???)
* moved cleanup of files to afterEach instead of beforeEach.  This seemed to fix issues related to `createTemporaryFiles` which were throwing `ENOENT` errors when trying to write files.