### PR TITLE
chore(package): use the `prepublishOnly` script instead of `prepublish`

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "babel-codemod rewrites JavaScript using babel plugins.",
   "main": "src/index.js",
   "scripts": {
-    "prepublish": "yarn test",
+    "prepublishOnly": "yarn test",
     "lint": "tslint --project .",
     "lint-fix": "tslint --project . --fix",
     "pretest": "yarn lint && tsc --project .",


### PR DESCRIPTION
This allows us to avoid running the tests twice, once when running `yarn install` and once when running `yarn test`.