### PR TITLE
feat(display): improve the informational output when running the CLI

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -63,9 +63,9 @@ EXAMPLES
 
 export default async function run(
   argv: Array<string>,
-  stdin: NodeJS.ReadableStream,
-  stdout: NodeJS.WritableStream,
-  stderr: NodeJS.WritableStream,
+  stdin: NodeJS.ReadStream,
+  stdout: NodeJS.WriteStream,
+  stderr: NodeJS.WriteStream,
   fs: typeof realFs = realFs
 ): Promise<number> {
   let options = Options.parse(argv.slice(2));
@@ -119,12 +119,17 @@ export default async function run(
 
   runner = new TransformRunner(sourcesIterator, plugins);
 
+  let dim = stdout.isTTY ? '\x1b[2m' : '';
+  let reset = stdout.isTTY ? '\x1b[0m' : '';
+
   for (let result of runner.run()) {
     if (result.output) {
       if (options.stdio) {
         stdout.write(`${result.output}\n`);
       } else {
-        if (result.output !== result.source.content) {
+        if (result.output === result.source.content) {
+          stdout.write(`${dim}${result.source.path}${reset}\n`);
+        } else {
           stats.modified++;
           stdout.write(`${result.source.path}\n`);
           if (!dryRun) {

--- a/test/cli/CLITest.ts
+++ b/test/cli/CLITest.ts
@@ -141,6 +141,21 @@ describe('CLI', function() {
     strictEqual(await readFile(afile, 'utf8'), '3 + 4;');
   });
 
+  it('prints files not processed in dim colors', async function() {
+    let afile = await createTemporaryFile('a-file.js', '3 + 4;');
+    let { status, stdout, stderr } = await runCodemodCLI([afile]);
+
+    deepEqual(
+      { status, stdout, stderr },
+      {
+        status: 0,
+        stdout: `${afile}\n1 file(s), 0 modified, 0 errors\n`,
+        stderr: ''
+      }
+    );
+    strictEqual(await readFile(afile, 'utf8'), '3 + 4;');
+  });
+
   it('can load plugins written with ES modules by default', async function() {
     let afile = await createTemporaryFile('a-file.js', '3 + 4;');
     let { status, stdout, stderr } = await runCodemodCLI([


### PR DESCRIPTION
`codemod` now prints all files it runs with, but dims those where there are no changes. This is similar to what prettier does. In addition, it prints the number of milliseconds taken to process each file.

<img width="670" alt="display" src="https://user-images.githubusercontent.com/1938/34929806-d5ee065a-f97a-11e7-87df-959f9e719680.png">
