### PR TITLE
fix: use our versions of the presets for transpiling

### DIFF
--- a/src/transpile-requires.ts
+++ b/src/transpile-requires.ts
@@ -30,10 +30,10 @@ export function hook(code: string, filename: string): string {
 
   if (!useBabelrc) {
     if (ext === '.ts') {
-      options.presets.push('@babel/preset-typescript');
+      options.presets.push(require.resolve('@babel/preset-typescript'));
     }
 
-    options.presets.push('@babel/preset-env');
+    options.presets.push(require.resolve('@babel/preset-env'));
   }
 
   return transform(code, options).code as string;


### PR DESCRIPTION
If you simply pass package names into babel's list of presets then it'll try to load them from the working directory. That doesn't work for us, so we need to resolve–but not load!–the presets relative to babel-codemod itself.

Fixes #102