### PR TITLE
fix: use all syntax plugins

### DIFF
--- a/src/AllSyntaxPlugin.ts
+++ b/src/AllSyntaxPlugin.ts
@@ -1,0 +1,28 @@
+import * as Babel from '@babel/core';
+import { BabelOptions, ParseOptions } from './TransformRunner';
+
+export const ALL_PLUGINS = [
+  'flow',
+  'jsx',
+  'asyncGenerators',
+  'classProperties',
+  'doExpressions',
+  'exportExtensions',
+  'functionBind',
+  'functionSent',
+  'objectRestSpread',
+  'dynamicImport',
+  'decorators'
+];
+
+export default function(babel: typeof Babel) {
+  return {
+    manipulateOptions(opts: BabelOptions, parserOpts: ParseOptions) {
+      for (let plugin of ALL_PLUGINS) {
+        if (plugin !== 'flow' || !opts.filename.endsWith('.ts')) {
+          parserOpts.plugins.push(plugin);
+        }
+      }
+    }
+  };
+}

--- a/src/Options.ts
+++ b/src/Options.ts
@@ -4,6 +4,7 @@ import { hasMagic as hasGlob, sync as globSync } from 'glob';
 import { basename, extname, resolve } from 'path';
 import { sync as resolveSync } from 'resolve';
 import { install } from 'source-map-support';
+import AllSyntaxPlugin from './AllSyntaxPlugin';
 import { PathPredicate } from './iterateSources';
 import PluginLoader from './PluginLoader';
 import RecastPlugin from './RecastPlugin';
@@ -125,7 +126,7 @@ export default class Options {
   }
 
   async getBabelPlugins(): Promise<Array<BabelPlugin>> {
-    let result: Array<BabelPlugin> = [RecastPlugin];
+    let result: Array<BabelPlugin> = [AllSyntaxPlugin, RecastPlugin];
 
     for (let plugin of await this.getPlugins()) {
       let options =

--- a/src/RecastPlugin.ts
+++ b/src/RecastPlugin.ts
@@ -1,6 +1,7 @@
 import * as Babel from '@babel/core';
 import { GeneratorOptions } from '@babel/generator';
 import * as recast from 'recast';
+import { ALL_PLUGINS } from './AllSyntaxPlugin';
 import { AST, ParseOptions } from './TransformRunner';
 
 const DEFAULT_OPTIONS = {
@@ -8,22 +9,10 @@ const DEFAULT_OPTIONS = {
   allowImportExportEverywhere: true,
   allowReturnOutsideFunction: true,
   allowSuperOutsideMethod: true,
-  plugins: [
-    'flow',
-    'jsx',
-    'asyncGenerators',
-    'classProperties',
-    'doExpressions',
-    'exportExtensions',
-    'functionBind',
-    'functionSent',
-    'objectRestSpread',
-    'dynamicImport',
-    'decorators'
-  ]
+  plugins: ALL_PLUGINS
 };
 
-export default function(babel: Babel) {
+export default function(babel: typeof Babel) {
   return {
     parserOverride(
       code: string,

--- a/src/TransformRunner.ts
+++ b/src/TransformRunner.ts
@@ -15,7 +15,12 @@ export class SourceTransformResult {
   ) {}
 }
 
-export type ParseOptions = object;
+export interface BabelOptions {
+  filename: string;
+}
+export interface ParseOptions {
+  plugins: Array<string>;
+}
 export type AST = object;
 
 export type RawBabelPlugin = (
@@ -23,6 +28,7 @@ export type RawBabelPlugin = (
 ) => {
   name?: string;
   visitor?: Visitor;
+  manipulateOptions?: (opts: object, parserOpts: ParseOptions) => void;
   parserOverride?: (
     code: string,
     options: ParseOptions,

--- a/src/transpile-requires.ts
+++ b/src/transpile-requires.ts
@@ -1,6 +1,7 @@
 import { transform } from '@babel/core';
 import { extname } from 'path';
 import { addHook } from 'pirates';
+import AllSyntaxPlugin from './AllSyntaxPlugin';
 
 let useBabelrc = false;
 let revert: (() => void) | null = null;
@@ -25,6 +26,7 @@ export function hook(code: string, filename: string): string {
     filename,
     babelrc: useBabelrc,
     presets: [] as Array<string>,
+    plugins: [AllSyntaxPlugin],
     sourceMaps: 'inline'
   };
 


### PR DESCRIPTION
When transpiling required files we need to be pretty liberal about what syntax we allow, otherwise we can end up in a situation where the current node version can actually parse more natively than babylon is allowed to by `@babel/preset-env`. This should fix that.

Fixes #102 

cc @RIP21