### PR TITLE
fix: ensure plugin errors are printed

### DIFF
--- a/src/CLIEngine.ts
+++ b/src/CLIEngine.ts
@@ -70,8 +70,9 @@ export default class CLIEngine {
     runner = new TransformRunner(sourcesIterator, plugins);
 
     for (let result of runner.run()) {
+      this.onTransform(result);
+
       if (result.output) {
-        this.onTransform(result);
         if (this.config.stdio) {
           this.writeStdout(result.output);
         } else {

--- a/test/cli/CLITest.ts
+++ b/test/cli/CLITest.ts
@@ -48,6 +48,20 @@ describe('CLI', function() {
     );
   });
 
+  it('fails with an error when a plugin throws an exception', async function() {
+    let { status, stdout, stderr } = await runCodemodCLI(
+      ['--plugin', plugin('bad-plugin'), '--stdio'],
+      '3+4'
+    );
+
+    strictEqual(status, 1);
+    strictEqual(stdout, '');
+    ok(
+      stderr.startsWith('Error: I am a bad plugin'),
+      `stderr should start with "Error: I am a bad plugin", got: ${stderr}`
+    );
+  });
+
   it('can read from stdin and write to stdout given the --stdio flag', async function() {
     let { status, stdout, stderr } = await runCodemodCLI(['--stdio'], '3+4');
 

--- a/test/fixtures/plugin/bad-plugin.js
+++ b/test/fixtures/plugin/bad-plugin.js
@@ -1,0 +1,9 @@
+module.exports = function() {
+  return {
+    visitor: {
+      NumericLiteral(path) {
+        throw new Error('I am a bad plugin');
+      }
+    }
+  };
+};


### PR DESCRIPTION
I neglected to preserve the call to `onTransform` in error cases.