### PR TITLE
feat(cli): allow adding extensions rather than replacing them all

### DIFF
--- a/src/Config.ts
+++ b/src/Config.ts
@@ -187,7 +187,7 @@ export class ConfigBuilder {
   private _remotePlugins?: Array<string>;
   private _pluginOptions?: Map<string, object>;
   private _printer?: Printer;
-  private _extensions?: Set<string>;
+  private _extensions: Set<string> = new Set(DEFAULT_EXTENSIONS);
   private _requires?: Array<string>;
   private _transpilePlugins?: boolean;
   private _findBabelConfig?: boolean;

--- a/src/Options.ts
+++ b/src/Options.ts
@@ -106,6 +106,11 @@ export default class Options {
           );
           break;
 
+        case '--add-extension':
+          i++;
+          config.addExtension(this.args[i]);
+          break;
+
         case '-s':
         case '--stdio':
           config.stdio(true);

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,7 @@ OPTIONS
   -r, --require PATH                Require PATH before transform${optionAnnotation(
     defaults.requires
   )}.
+      --add-extension EXT           Add an extension to the list of supported extensions.
       --extensions EXTS             Comma-separated extensions to process (default: "${Array.from(
         defaults.extensions
       ).join(',')}").

--- a/test/unit/OptionsTest.ts
+++ b/test/unit/OptionsTest.ts
@@ -29,6 +29,11 @@ describe('Options', function() {
     deepEqual(config.extensions, new Set(['.js', '.jsx', '.ts']));
   });
 
+  it('--add-extension adds to the default extensions', function() {
+    let config = getRunConfig(new Options(['--add-extension', '.ts']).parse());
+    deepEqual(config.extensions, new Set(['.js', '.jsx', '.ts']));
+  });
+
   it('fails to parse unknown options', function() {
     throws(() => new Options(['--wtf']).parse(), 'unexpected option: --wtf');
   });


### PR DESCRIPTION
This makes it easier to do one-off addition of extensions rather than having to hardcode the default values everywhere you want to include more.