### PR TITLE
test(ci): test with node v10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ cache:
 notifications:
   email: true
 node_js:
+  - '10'
   - '9'
   - '8'
   - '6'

--- a/test/unit/OptionsTest.ts
+++ b/test/unit/OptionsTest.ts
@@ -35,7 +35,11 @@ describe('Options', function() {
   });
 
   it('fails to parse unknown options', function() {
-    throws(() => new Options(['--wtf']).parse(), 'unexpected option: --wtf');
+    throws(
+      () => new Options(['--wtf']).parse(),
+      Error,
+      'unexpected option: --wtf'
+    );
   });
 
   it('interprets non-option arguments as paths', function() {


### PR DESCRIPTION
We may want to drop node v6 at some point, but there's not compelling reason to right now.