### PR TITLE
fix(prettier): silence parser warning

### DIFF
--- a/src/PrettierPrinterPlugin.ts
+++ b/src/PrettierPrinterPlugin.ts
@@ -16,6 +16,13 @@ function loadPrettier(): typeof Prettier {
 export default function(babel: typeof Babel) {
   let prettier = loadPrettier();
 
+  function resolvePrettierConfig(filepath: string): Prettier.Options {
+    return {
+      ...(prettier.resolveConfig.sync(filepath) || undefined),
+      filepath
+    };
+  }
+
   return {
     parserOverride: parse,
     generatorOverride(
@@ -27,7 +34,7 @@ export default function(babel: typeof Babel) {
       return {
         code: prettier.format(
           generate(ast, options, code, _generate).code,
-          prettier.resolveConfig.sync(options.filename) || undefined
+          resolvePrettierConfig(options.filename)
         )
       };
     }


### PR DESCRIPTION
Prettier warns when it does not have a parser or filepath because it can't know what type of code it is that it should be reformatting. This silences that warning by providing prettier with the filepath to process so it can automatically determine which parser to use.