### PR TITLE
fix(astexplorer): accept non-SSL URLs

### DIFF
--- a/src/resolvers/AstExplorerResolver.ts
+++ b/src/resolvers/AstExplorerResolver.ts
@@ -84,8 +84,11 @@ export default class AstExplorerResolver extends NetworkResolver {
   }
 
   private matchesHost(url: URL): boolean {
-    return (
-      url.protocol === this.baseURL.protocol && url.host === this.baseURL.host
-    );
+    if (url.host !== this.baseURL.host) {
+      return false;
+    }
+
+    // use SSL even if the URL doesn't use it
+    return url.protocol === this.baseURL.protocol || url.protocol === 'http:';
   }
 }

--- a/test/unit/resolvers/AstExplorerResolverTest.ts
+++ b/test/unit/resolvers/AstExplorerResolverTest.ts
@@ -17,6 +17,18 @@ describe('AstExplorerResolver', function() {
     );
   });
 
+  it('normalizes http gist+commit editor URL to an https API URL', async function() {
+    let resolver = new AstExplorerResolver();
+    let normalized = await resolver.normalize(
+      'http://astexplorer.net/#/gist/b5b33c/f9ae8a'
+    );
+
+    strictEqual(
+      normalized,
+      'https://astexplorer.net/api/v1/gist/b5b33c/f9ae8a'
+    );
+  });
+
   it('normalizes a gist-only editor URL into an API URL', async function() {
     let resolver = new AstExplorerResolver();
     let normalized = await resolver.normalize(


### PR DESCRIPTION
Since astexplorer.net doesn't force SSL, users might be using it without SSL. When they copy the URL, it'll be `http` instead of `https`. We now accept such URLs, but turn them into `https` when normalizing them.