### PR TITLE
feat(typescript): process TypeScript files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # babel-codemod
 
-babel-codemod rewrites JavaScript using babel plugins.
+babel-codemod rewrites JavaScript and TypeScript using babel plugins.
 
 ## Install
 
@@ -21,10 +21,13 @@ The primary interface is as a command line tool, usually run like so:
 ```sh
 $ codemod --plugin transform-module-name \
   path/to/file.js \
-  another/file.js
+  another/file.js \
+  a/directory
 ```
 
-This will re-write the files `path/to/file.js` and `another/file.js` by transforming them with the babel plugin `transform-module-name`. Multiple plugins may be specified, and multiple files or directories may be re-written at once.
+This will re-write the files `path/to/file.js`, `another/file.js`, and any supported files found in `a/directory` by transforming them with the babel plugin `transform-module-name`. Multiple plugins may be specified, and multiple files or directories may be re-written at once.
+
+Note that TypeScript support is provided by babel and therefore may not completely support all valid TypeScript code. If you encounter an issue, consider looking for it in the [babel issues labeled `area: typescript`](https://github.com/babel/babel/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+label%3A%22area%3A+typescript%22+) before filing an issue with babel-codemod.
 
 Plugins may also be loaded from remote URLs, including saved [AST Explorer](https://astexplorer.net/) URLs, using `--remote-plugin`. This feature should only be used as a convenience to load code that you or someone you trust wrote. It will run with your full user privileges, so please exercise caution!
 

--- a/src/AllSyntaxPlugin.ts
+++ b/src/AllSyntaxPlugin.ts
@@ -1,8 +1,9 @@
 import * as Babel from '@babel/core';
+import { extname } from 'path';
 import { BabelOptions, ParseOptions } from './BabelPluginTypes';
+import { TypeScriptExtensions } from './extensions';
 
-export const ALL_PLUGINS = [
-  'flow',
+const BASIC_PLUGINS = [
   'jsx',
   'asyncGenerators',
   'classProperties',
@@ -15,14 +16,25 @@ export const ALL_PLUGINS = [
   'decorators'
 ];
 
+function pluginsForFilename(filename: string): Array<string> {
+  let isTypeScript = TypeScriptExtensions.has(extname(filename));
+
+  return isTypeScript
+    ? [...BASIC_PLUGINS, 'typescript']
+    : [...BASIC_PLUGINS, 'flow'];
+}
+
 export default function(babel: typeof Babel) {
   return {
     manipulateOptions(opts: BabelOptions, parserOpts: ParseOptions) {
-      for (let plugin of ALL_PLUGINS) {
-        if (plugin !== 'flow' || !opts.filename.endsWith('.ts')) {
-          parserOpts.plugins.push(plugin);
-        }
-      }
+      parserOpts.sourceType = 'module';
+      parserOpts.allowImportExportEverywhere = true;
+      parserOpts.allowReturnOutsideFunction = true;
+      parserOpts.allowSuperOutsideMethod = true;
+      parserOpts.plugins = [
+        ...(parserOpts.plugins || []),
+        ...pluginsForFilename(opts.filename)
+      ];
     }
   };
 }

--- a/src/BabelPluginTypes.ts
+++ b/src/BabelPluginTypes.ts
@@ -6,7 +6,11 @@ export interface BabelOptions {
   filename: string;
 }
 export interface ParseOptions {
-  plugins: Array<string>;
+  sourceType?: 'module' | 'script';
+  allowImportExportEverywhere?: boolean;
+  allowReturnOutsideFunction?: boolean;
+  allowSuperOutsideMethod?: boolean;
+  plugins?: Array<string>;
 }
 export type AST = object;
 

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -4,6 +4,7 @@ import { install } from 'source-map-support';
 import AllSyntaxPlugin from './AllSyntaxPlugin';
 import { BabelPlugin, RawBabelPlugin } from './BabelPluginTypes';
 import BabelPrinterPlugin from './BabelPrinterPlugin';
+import { TransformableExtensions } from './extensions';
 import { PathPredicate } from './iterateSources';
 import PluginLoader from './PluginLoader';
 import PrettierPrinterPlugin from './PrettierPrinterPlugin';
@@ -13,8 +14,6 @@ import FileSystemResolver from './resolvers/FileSystemResolver';
 import NetworkResolver from './resolvers/NetworkResolver';
 import PackageResolver from './resolvers/PackageResolver';
 import { disable, enable } from './transpile-requires';
-
-export const DEFAULT_EXTENSIONS = new Set(['.js', '.jsx']);
 
 export class Plugin {
   readonly declaredName?: string;
@@ -50,7 +49,7 @@ export default class Config {
     readonly remotePlugins: Array<string> = [],
     readonly pluginOptions: Map<string, object> = new Map<string, object>(),
     readonly printer: Printer = Printer.Recast,
-    readonly extensions: Set<string> = DEFAULT_EXTENSIONS,
+    readonly extensions: Set<string> = TransformableExtensions,
     readonly requires: Array<string> = [],
     readonly transpilePlugins: boolean = true,
     readonly findBabelConfig: boolean = false,
@@ -187,7 +186,7 @@ export class ConfigBuilder {
   private _remotePlugins?: Array<string>;
   private _pluginOptions?: Map<string, object>;
   private _printer?: Printer;
-  private _extensions: Set<string> = new Set(DEFAULT_EXTENSIONS);
+  private _extensions: Set<string> = new Set(TransformableExtensions);
   private _requires?: Array<string>;
   private _transpilePlugins?: boolean;
   private _findBabelConfig?: boolean;

--- a/src/Options.ts
+++ b/src/Options.ts
@@ -3,7 +3,7 @@ import { hasMagic as hasGlob, sync as globSync } from 'glob';
 import { resolve } from 'path';
 import { sync as resolveSync } from 'resolve';
 import Config, { ConfigBuilder, Printer } from './Config';
-import { SUPPORTED_EXTENSIONS } from './transpile-requires';
+import { RequireableExtensions } from './extensions';
 
 export interface RunCommand {
   kind: 'run';
@@ -157,7 +157,7 @@ function getRequirableModulePath(modulePath: string): string {
     return resolve(modulePath);
   }
 
-  for (let ext of SUPPORTED_EXTENSIONS) {
+  for (let ext of RequireableExtensions) {
     if (existsSync(modulePath + ext)) {
       return resolve(modulePath + ext);
     }

--- a/src/RecastPlugin.ts
+++ b/src/RecastPlugin.ts
@@ -1,16 +1,7 @@
 import * as Babel from '@babel/core';
 import { GeneratorOptions } from '@babel/generator';
 import * as recast from 'recast';
-import { ALL_PLUGINS } from './AllSyntaxPlugin';
 import { AST, ParseOptions } from './BabelPluginTypes';
-
-const DEFAULT_OPTIONS = {
-  sourceType: 'module',
-  allowImportExportEverywhere: true,
-  allowReturnOutsideFunction: true,
-  allowSuperOutsideMethod: true,
-  plugins: ALL_PLUGINS
-};
 
 export function parse(
   code: string,
@@ -20,7 +11,7 @@ export function parse(
   return recast.parse(code, {
     parser: {
       parse(code: string) {
-        return parse(code, DEFAULT_OPTIONS);
+        return parse(code, options);
       }
     }
   });

--- a/src/extensions.ts
+++ b/src/extensions.ts
@@ -1,0 +1,24 @@
+function union<T>(...sets: Array<Set<T>>) {
+  return new Set(sets.reduce((result, set) => [...result, ...set], []));
+}
+
+export const TypeScriptExtensions = new Set(['.ts', '.tsx']);
+export const JavaScriptExtensions = new Set([
+  '.js',
+  '.jsx',
+  '.mjs',
+  '.es',
+  '.es6'
+]);
+export const PluginExtensions = union(
+  TypeScriptExtensions,
+  JavaScriptExtensions
+);
+export const RequireableExtensions = union(
+  TypeScriptExtensions,
+  JavaScriptExtensions
+);
+export const TransformableExtensions = union(
+  TypeScriptExtensions,
+  JavaScriptExtensions
+);

--- a/src/index.ts
+++ b/src/index.ts
@@ -83,6 +83,9 @@ EXAMPLES
   # Run with multiple plugins.
   $ ${$0} -p ./a.js -p ./b.js some-file.js
 
+  # Transform TypeScript sources.
+  # ${$0} -p ./a.js my-typescript-file.ts a-component.tsx
+
   # Run with a plugin in \`node_modules\` on stdin.
   $ ${$0} -s -p babel-plugin-typecheck <<EOS
   function add(a: number, b: number): number {

--- a/src/resolvers/FileSystemResolver.ts
+++ b/src/resolvers/FileSystemResolver.ts
@@ -1,6 +1,6 @@
 import { stat } from 'mz/fs';
 import { resolve } from 'path';
-import { SUPPORTED_EXTENSIONS } from '../transpile-requires';
+import { PluginExtensions } from '../extensions';
 import Resolver from './Resolver';
 
 async function isFile(path: string): Promise<boolean> {
@@ -16,7 +16,7 @@ async function isFile(path: string): Promise<boolean> {
  */
 export default class FileSystemResolver implements Resolver {
   constructor(
-    private readonly optionalExtensions: Set<string> = SUPPORTED_EXTENSIONS
+    private readonly optionalExtensions: Set<string> = PluginExtensions
   ) {}
 
   private *enumerateCandidateSources(source: string): IterableIterator<string> {

--- a/src/transpile-requires.ts
+++ b/src/transpile-requires.ts
@@ -2,23 +2,15 @@ import { transform } from '@babel/core';
 import { extname } from 'path';
 import { addHook } from 'pirates';
 import AllSyntaxPlugin from './AllSyntaxPlugin';
+import { PluginExtensions, TypeScriptExtensions } from './extensions';
 
 let useBabelrc = false;
 let revert: (() => void) | null = null;
 
-export const SUPPORTED_EXTENSIONS = new Set([
-  '.js',
-  '.jsx',
-  '.es',
-  '.es6',
-  '.mjs',
-  '.ts'
-]);
-
 export function hook(code: string, filename: string): string {
   let ext = extname(filename);
 
-  if (!SUPPORTED_EXTENSIONS.has(ext)) {
+  if (!PluginExtensions.has(ext)) {
     throw new Error(`cannot load file type '${ext}': ${filename}`);
   }
 
@@ -31,7 +23,7 @@ export function hook(code: string, filename: string): string {
   };
 
   if (!useBabelrc) {
-    if (ext === '.ts') {
+    if (TypeScriptExtensions.has(ext)) {
       options.presets.push(require.resolve('@babel/preset-typescript'));
     }
 
@@ -45,7 +37,7 @@ export function enable(babelrc: boolean = false) {
   disable();
   useBabelrc = babelrc;
   revert = addHook(hook, {
-    exts: Array.from(SUPPORTED_EXTENSIONS),
+    exts: Array.from(PluginExtensions),
     ignoreNodeModules: true
   });
 }

--- a/test/fixtures/plugin/replace-any-with-object.ts
+++ b/test/fixtures/plugin/replace-any-with-object.ts
@@ -1,0 +1,14 @@
+import * as Babel from '@babel/core';
+import { NodePath } from '@babel/traverse';
+
+export default function(babel: typeof Babel) {
+  const { types: t } = babel;
+
+  return {
+    visitor: {
+      TSAnyKeyword(path: NodePath) {
+        path.replaceWith(t.tsObjectKeyword());
+      }
+    }
+  };
+}

--- a/test/unit/ConfigTest.ts
+++ b/test/unit/ConfigTest.ts
@@ -1,4 +1,4 @@
-import { deepEqual, strictEqual } from 'assert';
+import { deepEqual, ok, strictEqual } from 'assert';
 import { inspect } from 'util';
 import Config, { ConfigBuilder } from '../../src/Config';
 
@@ -7,7 +7,10 @@ import Config, { ConfigBuilder } from '../../src/Config';
 describe('Config', function() {
   it('has sensible defaults', function() {
     let config = new Config();
-    deepEqual(config.extensions, new Set(['.js', '.jsx']));
+    ok(config.extensions.has('.js'));
+    ok(config.extensions.has('.ts'));
+    ok(config.extensions.has('.jsx'));
+    ok(config.extensions.has('.tsx'));
     deepEqual(config.localPlugins, []);
     deepEqual(config.sourcePaths, []);
     deepEqual(config.requires, []);

--- a/test/unit/OptionsTest.ts
+++ b/test/unit/OptionsTest.ts
@@ -1,4 +1,4 @@
-import { deepEqual, strictEqual, throws } from 'assert';
+import { deepEqual, ok, strictEqual, throws } from 'assert';
 import { inspect } from 'util';
 import Config, { Printer } from '../../src/Config';
 import Options, { Command } from '../../src/Options';
@@ -6,7 +6,10 @@ import Options, { Command } from '../../src/Options';
 describe('Options', function() {
   it('has sensible defaults', function() {
     let config = getRunConfig(new Options([]).parse());
-    deepEqual(config.extensions, new Set(['.js', '.jsx']));
+    ok(config.extensions.has('.js'));
+    ok(config.extensions.has('.ts'));
+    ok(config.extensions.has('.jsx'));
+    ok(config.extensions.has('.tsx'));
     deepEqual(config.localPlugins, []);
     deepEqual(config.sourcePaths, []);
     deepEqual(config.requires, []);
@@ -23,15 +26,16 @@ describe('Options', function() {
   });
 
   it('interprets `--extensions` as expected', function() {
-    let config = getRunConfig(
-      new Options(['--extensions', '.js,.jsx,.ts']).parse()
-    );
-    deepEqual(config.extensions, new Set(['.js', '.jsx', '.ts']));
+    let config = getRunConfig(new Options(['--extensions', '.js,.ts']).parse());
+    deepEqual(config.extensions, new Set(['.js', '.ts']));
   });
 
   it('--add-extension adds to the default extensions', function() {
-    let config = getRunConfig(new Options(['--add-extension', '.ts']).parse());
-    deepEqual(config.extensions, new Set(['.js', '.jsx', '.ts']));
+    let config = getRunConfig(
+      new Options(['--add-extension', '.myjs']).parse()
+    );
+    ok(config.extensions.size > 1);
+    ok(config.extensions.has('.myjs'));
   });
 
   it('fails to parse unknown options', function() {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,15 +2,12 @@
   "compilerOptions": {
     "module": "commonjs",
     "target": "es2015",
-    "lib": [
-      "es2015",
-      "es2016"
-    ],
+    "lib": ["es2015", "es2016"],
     "noImplicitAny": false,
     "sourceMap": true,
     "strictNullChecks": true,
     "declaration": true
   },
-  "exclude": ["test/fixtures/**/*.ts"],
+  "exclude": ["test/fixtures/**/*.ts", "tmp"],
   "compileOnSave": true
 }


### PR DESCRIPTION
To support TypeScript, mostly we just needed to use the `typescript` parser plugin when the file being processed is TypeScript.

BREAKING CHANGE: This expands the set of file extensions that babel-codemod will look for to include `.ts`, `.tsx`, `.es`, `.es6`, and `.mjs` in addition to `.js` and `.jsx`.

Closes #137