### PR TITLE
refactor(transform): use a tagged union for results

### DIFF
--- a/src/CLIEngine.ts
+++ b/src/CLIEngine.ts
@@ -7,7 +7,8 @@ import iterateSources from './iterateSources';
 import ProcessSnapshot from './ProcessSnapshot';
 import TransformRunner, {
   Source,
-  SourceTransformResult
+  SourceTransformResult,
+  SourceTransformResultKind
 } from './TransformRunner';
 
 export class RunResult {
@@ -81,7 +82,7 @@ export default class CLIEngine {
     for await (let result of runner.run()) {
       this.onTransform(result);
 
-      if (result.output) {
+      if (result.kind === SourceTransformResultKind.Transformed) {
         if (this.config.stdio) {
           this.writeStdout(result.output);
         } else {

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,10 @@ import { basename } from 'path';
 import CLIEngine from './CLIEngine';
 import Config from './Config';
 import Options, { Command } from './Options';
-import { SourceTransformResult } from './TransformRunner';
+import {
+  SourceTransformResult,
+  SourceTransformResultKind
+} from './TransformRunner';
 
 // Polyfill `Symbol.asyncIterator` so `for await` will work.
 if (!Symbol.asyncIterator) {
@@ -146,7 +149,7 @@ export default async function run(
   let reset = stdout.isTTY ? '\x1b[0m' : '';
 
   function onTransform(result: SourceTransformResult): void {
-    if (result.output) {
+    if (result.kind === SourceTransformResultKind.Transformed) {
       if (!config.stdio) {
         if (result.output === result.source.content) {
           stdout.write(`${dim}${result.source.path}${reset}\n`);

--- a/test/unit/TransformRunnerTest.ts
+++ b/test/unit/TransformRunnerTest.ts
@@ -1,7 +1,8 @@
 import { deepEqual } from 'assert';
 import TransformRunner, {
   Source,
-  SourceTransformResult
+  SourceTransformResult,
+  SourceTransformResultKind
 } from '../../src/TransformRunner';
 
 describe('TransformRunner', function() {
@@ -24,8 +25,16 @@ describe('TransformRunner', function() {
     });
 
     deepEqual(await run(runner), [
-      new SourceTransformResult(sources[0], 'A;', null),
-      new SourceTransformResult(sources[1], 'B;', null)
+      {
+        kind: SourceTransformResultKind.Transformed,
+        source: sources[0],
+        output: 'A;'
+      },
+      {
+        kind: SourceTransformResultKind.Transformed,
+        source: sources[1],
+        output: 'B;'
+      }
     ]);
   });
 
@@ -38,11 +47,11 @@ describe('TransformRunner', function() {
     });
 
     deepEqual(await run(runner), [
-      new SourceTransformResult(
-        sources[0],
-        null,
-        new Error('unable to process fails.js: invalid syntax')
-      )
+      {
+        kind: SourceTransformResultKind.Error,
+        source: sources[0],
+        error: new Error('unable to process fails.js: invalid syntax')
+      }
     ]);
   });
 });


### PR DESCRIPTION
Rather than using a class with nullable values for the two cases (transformed/errored), it's better from a type-checking perspective to use a tagged union.