### PR TITLE
chore(husky): move hooks to `husky.hook`

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,12 +8,7 @@
     "lint": "tslint --project .",
     "lint-fix": "tslint --project . --fix",
     "pretest": "yarn lint && tsc --project .",
-    "test": "mocha \"test/**/*Test.js\"",
-    "commitmsg": "commitlint -e $GIT_PARAMS",
-    "precommit": "lint-staged",
-    "postmerge": "yarnhook",
-    "postcheckout": "yarnhook",
-    "postrewrite": "yarnhook"
+    "test": "mocha \"test/**/*Test.js\""
   },
   "lint-staged": {
     "*.ts": [
@@ -93,5 +88,14 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/square/babel-codemod.git"
+  },
+  "husky": {
+    "hooks": {
+      "commit-msg": "commitlint -e $GIT_PARAMS",
+      "post-checkout": "yarnhook",
+      "post-merge": "yarnhook",
+      "post-rewrite": "yarnhook",
+      "pre-commit": "lint-staged"
+    }
   }
 }


### PR DESCRIPTION
This change was done using `husky-upgrade`.