### PR TITLE
feat: let babel guess the source type

### DIFF
--- a/src/AllSyntaxPlugin.ts
+++ b/src/AllSyntaxPlugin.ts
@@ -1,7 +1,7 @@
 import * as Babel from '@babel/core';
 import { ParserPlugin } from '@babel/parser';
 import { extname } from 'path';
-import { PluginObj } from './BabelPluginTypes';
+import { BabelPlugin, PluginObj } from './BabelPluginTypes';
 import { TypeScriptExtensions } from './extensions';
 
 const BASIC_PLUGINS: Array<ParserPlugin | [ParserPlugin, object]> = [
@@ -26,21 +26,25 @@ function pluginsForFilename(
     : [...BASIC_PLUGINS, 'flow'];
 }
 
-export default function(babel: typeof Babel): PluginObj {
-  return {
-    manipulateOptions(
-      opts: Babel.TransformOptions,
-      parserOpts: Babel.ParserOptions
-    ): void {
-      parserOpts.sourceType = 'module';
-      parserOpts.allowImportExportEverywhere = true;
-      parserOpts.allowReturnOutsideFunction = true;
-      parserOpts.allowSuperOutsideMethod = true;
-      // Cast this because @babel/types typings don't allow plugin options.
-      parserOpts.plugins = [
-        ...(parserOpts.plugins || []),
-        ...pluginsForFilename(opts.filename as string)
-      ] as Array<ParserPlugin>;
-    }
+export default function buildPlugin(
+  sourceType: Babel.ParserOptions['sourceType']
+): BabelPlugin {
+  return function(babel: typeof Babel): PluginObj {
+    return {
+      manipulateOptions(
+        opts: Babel.TransformOptions,
+        parserOpts: Babel.ParserOptions
+      ): void {
+        parserOpts.sourceType = sourceType;
+        parserOpts.allowImportExportEverywhere = true;
+        parserOpts.allowReturnOutsideFunction = true;
+        parserOpts.allowSuperOutsideMethod = true;
+        // Cast this because @babel/types typings don't allow plugin options.
+        parserOpts.plugins = [
+          ...(parserOpts.plugins || []),
+          ...pluginsForFilename(opts.filename as string)
+        ] as Array<ParserPlugin>;
+      }
+    };
   };
 }

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -1,7 +1,8 @@
 import * as Babel from '@babel/core';
+import { ParserOptions } from '@babel/parser';
 import { basename, extname } from 'path';
 import { install } from 'source-map-support';
-import AllSyntaxPlugin from './AllSyntaxPlugin';
+import buildAllSyntaxPlugin from './AllSyntaxPlugin';
 import { BabelPlugin, RawBabelPlugin } from './BabelPluginTypes';
 import BabelPrinterPlugin from './BabelPrinterPlugin';
 import { TransformableExtensions } from './extensions';
@@ -50,6 +51,7 @@ export default class Config {
     readonly pluginOptions: Map<string, object> = new Map<string, object>(),
     readonly printer: Printer = Printer.Recast,
     readonly extensions: Set<string> = TransformableExtensions,
+    readonly sourceType: ParserOptions['sourceType'] = 'unambiguous',
     readonly requires: Array<string> = [],
     readonly transpilePlugins: boolean = true,
     readonly findBabelConfig: boolean = false,
@@ -132,7 +134,7 @@ export default class Config {
   }
 
   async getBabelPlugins(): Promise<Array<BabelPlugin>> {
-    let result: Array<BabelPlugin> = [AllSyntaxPlugin];
+    let result: Array<BabelPlugin> = [buildAllSyntaxPlugin(this.sourceType)];
 
     switch (this.printer) {
       case Printer.Recast:
@@ -187,6 +189,7 @@ export class ConfigBuilder {
   private _pluginOptions?: Map<string, object>;
   private _printer?: Printer;
   private _extensions: Set<string> = new Set(TransformableExtensions);
+  private _sourceType: ParserOptions['sourceType'] = 'module';
   private _requires?: Array<string>;
   private _transpilePlugins?: boolean;
   private _findBabelConfig?: boolean;
@@ -271,6 +274,11 @@ export class ConfigBuilder {
     return this;
   }
 
+  sourceType(value: ParserOptions['sourceType']): this {
+    this._sourceType = value;
+    return this;
+  }
+
   requires(value: Array<string>): this {
     this._requires = value;
     return this;
@@ -317,6 +325,7 @@ export class ConfigBuilder {
       this._pluginOptions,
       this._printer,
       this._extensions,
+      this._sourceType,
       this._requires,
       this._transpilePlugins,
       this._findBabelConfig,

--- a/src/InlineTransformer.ts
+++ b/src/InlineTransformer.ts
@@ -1,5 +1,6 @@
 import { transformAsync } from '@babel/core';
 import { BabelPlugin } from './BabelPluginTypes';
+import Config from './Config';
 import Transformer from './Transformer';
 
 export default class InlineTransformer implements Transformer {

--- a/src/Options.ts
+++ b/src/Options.ts
@@ -111,6 +111,24 @@ export default class Options {
           config.addExtension(this.args[i]);
           break;
 
+        case '--source-type': {
+          i++;
+          let sourceType = this.args[i];
+          if (
+            sourceType === 'module' ||
+            sourceType === 'script' ||
+            sourceType === 'unambiguous'
+          ) {
+            config.sourceType(sourceType);
+          } else {
+            throw new Error(
+              `expected '--source-type' to be one of "module", "script", ` +
+                `or "unambiguous" but got: "${sourceType}"`
+            );
+          }
+          break;
+        }
+
         case '-s':
         case '--stdio':
           config.stdio(true);

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,6 +54,10 @@ OPTIONS
       --extensions EXTS             Comma-separated extensions to process (default: "${Array.from(
         defaults.extensions
       ).join(',')}").
+      --source-type                 Parse as "module", "script", or "unambiguous" (meaning babel
+                                    will try to guess, default: "${
+                                      defaults.sourceType
+                                    }").
       --[no-]transpile-plugins      Transpile plugins to enable future syntax${optionAnnotation(
         defaults.transpilePlugins
       )}.

--- a/src/transpile-requires.ts
+++ b/src/transpile-requires.ts
@@ -1,7 +1,7 @@
 import { transformSync, TransformOptions } from '@babel/core';
 import { extname } from 'path';
 import { addHook } from 'pirates';
-import AllSyntaxPlugin from './AllSyntaxPlugin';
+import buildAllSyntaxPlugin from './AllSyntaxPlugin';
 import { PluginExtensions, TypeScriptExtensions } from './extensions';
 
 let useBabelrc = false;
@@ -19,7 +19,7 @@ export function hook(code: string, filename: string): string {
     filename,
     babelrc: useBabelrc,
     presets: presets,
-    plugins: [AllSyntaxPlugin],
+    plugins: [buildAllSyntaxPlugin('module')],
     sourceMaps: 'inline'
   };
 


### PR DESCRIPTION
Previously babel-codemod hardcoded a value of `module` for the source type when parsing. This meant that any code not valid in strict mode could not be processed. Now babel-codemod uses a default source type of `unambiguous`, which means that babel will try to infer the source type. Additionally, this source type can be overridden with the `--source-type` option.

Closes #175