### PR TITLE
fix: explicitly depend on `@babel/parser`

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
   "dependencies": {
     "@babel/core": "^7.1.6",
     "@babel/generator": "^7.1.6",
+    "@babel/parser": "^7.1.6",
     "@babel/preset-env": "^7.1.6",
     "@babel/preset-typescript": "^7.1.0",
     "@babel/traverse": "^7.1.6",


### PR DESCRIPTION
Since we import it directly we must depend on it directly, since without this the install may not work with some `node_modules` layouts (i.e. pnpm).